### PR TITLE
Update tinymce.js

### DIFF
--- a/src/tinymce.js
+++ b/src/tinymce.js
@@ -24,13 +24,14 @@ angular.module('ui.tinymce', [])
 
         var expression, options = {}, tinyInstance,
           updateView = function(editor) {
-            var content = editor.getContent({format: options.format}).trim();
+          	if (!editor.destroyed)
+            {var content = editor.getContent({format: options.format}).trim();
             content = $sce.trustAsHtml(content);
 
             ngModel.$setViewValue(content);
             if (!$rootScope.$$phase) {
               scope.$digest();
-            }
+            }}
           };
 
         function toggleDisable(disabled) {


### PR DESCRIPTION
When a user insert content and disposing the tinymce (for example - modal closing), theres a console error on updateView. This fix checks if the tinymce is destroyed before that.
